### PR TITLE
Remove inter-dependencies on data items and plot data items

### DIFF
--- a/specviz/plugins/model_editor/equation_editor_dialog.py
+++ b/specviz/plugins/model_editor/equation_editor_dialog.py
@@ -45,7 +45,7 @@ class ModelEquationEditorDialog(QDialog):
     def exec_(self):
         # Populate the drop down list with the model names
         self.model_list_combo_box.clear()
-        self.model_list_combo_box.addItems(self.model.fittable_models.keys())
+        self.model_list_combo_box.addItems(self.model.compose_fittable_models().keys())
 
         self.equation_text_edit.setPlainText(self.model.equation)
 
@@ -76,7 +76,7 @@ class ModelEquationEditorDialog(QDialog):
         full_string = self.equation_text_edit.toPlainText()
         self.model.equation = full_string
 
-        for var in self.model.fittable_models.keys():
+        for var in self.model.compose_fittable_models().keys():
             comp_reg = re.compile(r"\b{}\b".format(var))
 
             if len(comp_reg.findall(full_string)) > 0:

--- a/specviz/plugins/model_editor/items.py
+++ b/specviz/plugins/model_editor/items.py
@@ -1,19 +1,11 @@
 import numpy as np
 
-from astropy import units as u
-
-from specutils.spectra import Spectrum1D
-
 from ...core.items import DataItem
 
 
 class ModelDataItem(DataItem):
     def __init__(self, model, *args, **kwargs):
         self._model_editor_model = model
-
-        self._plot_data_item = None
-
-        self._special_args = {}
 
         super().__init__(*args, **kwargs)
 
@@ -24,29 +16,10 @@ class ModelDataItem(DataItem):
 
         result = self.model_editor_model.evaluate()
 
-        flux_units = self.data(self.DataRole).flux.unit
-
-        if self._plot_data_item is None:
-            model_flux_units = flux_units
-        else:
-            model_flux_units = u.Unit(self._plot_data_item.data_unit)
-
         if result is not None:
-            model_flux = result(self.model_spectral_axis.value) * model_flux_units
-            return model_flux.to(flux_units,
-                                 equivalencies=u.equivalencies.spectral_density(
-                                     self.model_spectral_axis))
+            return result(self.spectral_axis.value) * self.data(self.DataRole).flux.unit
 
-        return np.zeros(self.spectral_axis.size) * model_flux_units
-
-    @property
-    def model_spectral_axis(self):
-        if self._plot_data_item is None:
-            model_spectral_units = self.data(self.DataRole).spectral_axis.unit
-        else:
-            model_spectral_units = u.Unit(self._plot_data_item.spectral_axis_unit)
-        return self.spectral_axis.to(model_spectral_units,
-                                     equivalencies=u.equivalencies.spectral())
+        return np.zeros(self.spectral_axis.size) * self.data(self.DataRole).flux.unit
 
     @property
     def model_editor_model(self):
@@ -55,7 +28,3 @@ class ModelDataItem(DataItem):
     @model_editor_model.setter
     def model_editor_model(self, value):
         self._model_editor_model = value
-
-    @property
-    def spectrum(self):
-        return Spectrum1D(flux=self.flux, spectral_axis=self.model_spectral_axis)

--- a/specviz/plugins/model_editor/items.py
+++ b/specviz/plugins/model_editor/items.py
@@ -17,9 +17,10 @@ class ModelDataItem(DataItem):
         result = self.model_editor_model.evaluate()
 
         if result is not None:
-            return result(self.spectral_axis.value) * self.data(self.DataRole).flux.unit
+            flux = result(self.spectral_axis.value) * self.data(self.DataRole).flux.unit
+            self.data(self.DataRole)._data = flux.value
 
-        return np.zeros(self.spectral_axis.size) * self.data(self.DataRole).flux.unit
+        return self.data(self.DataRole).flux
 
     @property
     def model_editor_model(self):

--- a/specviz/plugins/model_editor/models.py
+++ b/specviz/plugins/model_editor/models.py
@@ -45,7 +45,7 @@ class ModelFittingModel(QStandardItemModel):
             # individual stored values
             for cidx in range(model_item.rowCount()):
                 param_name = model_item.child(cidx, 0).data()
-                param_value = float(model_item.child(cidx, 1).text())
+                param_value = model_item.child(cidx, 1).data()
                 param_unit = model_item.child(cidx, 2).data()
                 param_fixed = model_item.child(cidx, 3).checkState() == Qt.Checked
 

--- a/specviz/plugins/model_editor/models.py
+++ b/specviz/plugins/model_editor/models.py
@@ -33,18 +33,13 @@ class ModelFittingModel(QStandardItemModel):
         self._equation = value
         self.evaluate()
 
-    @property
-    def fittable_models(self):
+    def compose_fittable_models(self):
         # Recompose the model objects with the current values in each of its
         # parameter rows.
         fittable_models = {}
 
         for model_item in self.items:
             model_kwargs = {'name': model_item.text(), 'fixed': {}}
-
-            special_args = model_item._special_args
-            if special_args:
-                model_kwargs.update(special_args)
 
             # For each of the children `StandardItem`s, parse out their
             # individual stored values
@@ -62,7 +57,7 @@ class ModelFittingModel(QStandardItemModel):
 
         return fittable_models
 
-    def add_model(self, model, special_args={}):
+    def add_model(self, model):
         model_name = model.__class__.name
 
         model_count = len([self.item(idx) for idx in range(self.rowCount())
@@ -71,7 +66,6 @@ class ModelFittingModel(QStandardItemModel):
         model_name = model_name + str(model_count) if model_count > 0 else model_name
 
         model_item = QStandardItem(model_name)
-        model_item._special_args = special_args
         model_item.setData(model, Qt.UserRole + 1)
 
         for para_name in model.param_names:
@@ -84,7 +78,7 @@ class ModelFittingModel(QStandardItemModel):
             param_name.setEditable(False)
 
             # Store the data value of the parameter
-            param_value = QStandardItem("{}".format(parameter.value))
+            param_value = QStandardItem("{:.5g}".format(parameter.value))
             param_value.setData(parameter.value, Qt.UserRole + 1)
 
             # Store the unit information
@@ -127,7 +121,7 @@ class ModelFittingModel(QStandardItemModel):
         fittable_models : dict
             Mapping of tree view model variables names to their model instances.
         """
-        fittable_models = self.fittable_models
+        fittable_models = self.compose_fittable_models()
 
         # Create an evaluation namespace for use in parsing the string
         namespace = {}


### PR DESCRIPTION
Hey @robelgeda. Sorry for the long while on getting your PR reviews. I just had some minor issues with some of the implementation that I thought would be easier to parse as a PR against your branch than by combing through and commenting on lines of your PR.

Mainly, `DataItem`s should have no idea of the `PlotDataItem`s that represent them. You had been storing a reference to the `PlotDataItem` on the `ModelDataItem`, and using that generate new `Spectrum1D` objects when the `data` methods of the `ModelDataItem`'s `QStandardItem` already held that required information.

Second, we shouldn't be storing extraneous information on the `DataItems`. I removed the `_special_args` dict, and instead just created a new astropy model class with the `degree` of the polynomial already embedded inside.

I'm still a little concerned about the way the fitting information is being stored, but perhaps it's not a blocker right now.

Let me know what you think.